### PR TITLE
add sleep reaction to RequestThrottled

### DIFF
--- a/api.go
+++ b/api.go
@@ -213,6 +213,10 @@ func (a *Amazing) Request(params url.Values, result interface{}) error {
 		if err != nil {
 			return err
 		}
+		if errorResponse.Code == "RequestThrottled" {
+			time.Sleep(time.Second)
+			return a.Request(params, result)
+		}
 		return &errorResponse
 	}
 


### PR DESCRIPTION
I couldn't find an elegant way to get the AmazonError.Code to bubble up so I figured it would be okay to re-request if RequestThrottled
