### PR TITLE
Feature/requesttiming

### DIFF
--- a/api.go
+++ b/api.go
@@ -195,12 +195,19 @@ func (a *Amazing) Request(params url.Values, result interface{}) error {
 		return err
 	}
 
+	time_start := time.Now()
+
 	res, err := httpClient.Do(r)
 	if err != nil {
 		return err
 	}
 
 	defer res.Body.Close()
+
+	respTime := time.Since(time_start)
+	if respTime <= time.Second {
+		time.Sleep(time.Second - respTime)
+	}
 
 	if res.StatusCode != http.StatusOK {
 		b, err := ioutil.ReadAll(res.Body)

--- a/api.go
+++ b/api.go
@@ -205,7 +205,7 @@ func (a *Amazing) Request(params url.Values, result interface{}) error {
 	defer res.Body.Close()
 
 	respTime := time.Since(time_start)
-	if respTime <= time.Second {
+	if respTime < time.Second {
 		time.Sleep(time.Second - respTime)
 	}
 


### PR DESCRIPTION
This pretty much eliminates the `RequestThrottled` error. Amazon accepts 3600 requests an hour which comes down to 1 request a second.

What do you think about this? 